### PR TITLE
Fixed 'Mixed Content' error from Google Fonts

### DIFF
--- a/client/style/style.less
+++ b/client/style/style.less
@@ -1,4 +1,4 @@
-@import url("http://fonts.googleapis.com/css?family=Lato:300,400,700,300italic");
+@import url("//fonts.googleapis.com/css?family=Lato:300,400,700,300italic");
 @import "/client/style/bootstrap-variables.less";
 
 @footer-height: 250px;


### PR DESCRIPTION
The stylesheet makes an `http://` request to Google Fonts. When serving the site over HTTPS, this causes a "Mixed Content" error:

```
Mixed Content: The page at 'https://[my site]/' was loaded over HTTPS, but requested 
an insecure stylesheet 'http://fonts.googleapis.com/css?family=Lato:300,400,700,300italic'.
This request has been blocked; the content must be served over HTTPS.
```

While the "Add this code to your website" box on Google Fonts only suggests `http://`, my fix is also [a Google-approved solution](https://code.google.com/p/googlefontdirectory/issues/detail?id=107).