### PR TITLE
mobile bug: removed nested containers home.html

### DIFF
--- a/client/views/home/home.html
+++ b/client/views/home/home.html
@@ -5,7 +5,7 @@
         <header>
             <nav class="navbar navbar-default" role="navigation">
                 <div class="container">
-                    <div class="container">
+                    <div class="row">
                         <a class="navbar-brand" href="{{pathFor 'home'}}">{{Config.name}}</a>
                         <div id="main-nav" class="navbar-collapse">
                             <ul class="social-links">


### PR DESCRIPTION
Fix for mobile phone view where nested bootstrap containers prohibited `sidebar nav` from being fully hidden.  Making the child element `class="row"` solves this.