### PR TITLE
Declare global adminConfig via @AdminConfig

### DIFF
--- a/both/_config/adminConfig.coffee
+++ b/both/_config/adminConfig.coffee
@@ -1,4 +1,4 @@
-AdminConfig =
+@AdminConfig =
 	name: Config.name
 	collections : 
 		Posts: {
@@ -37,8 +37,3 @@ AdminConfig =
 		# ]
 	autoForm: 
 	        omitFields: ['createdAt', 'updatedAt']
-
-if Meteor.isClient
-	window.AdminConfig = AdminConfig
-else if Meteor.isServer
-	global.AdminConfig = AdminConfig


### PR DESCRIPTION
If there is a special reason, that you pass the config to [global] and [window] instead of [this] - like you did for the collections - I haven't seen it.